### PR TITLE
Add an 'eventkit' feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.1.0"
 authors = ["Cerek Hillen <cerekh@gmail.com>"]
 edition = "2018"
 
+[features]
+eventkit = ["objc"]
+
 [dependencies]
 block = "0.1.6"
 chrono = "0.4.19"
 lazy_static = "1.4.0"
-objc = { version = "0.2.7", features = ["exception"] }
+objc = { version = "0.2.7", features = ["exception"], optional = true }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.61"
 shellexpand = "2.1.0"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod edit;
 pub mod interactive;
 pub mod order;
+#[cfg(feature = "eventkit")]
 pub mod remind;
 
 use std::io;
@@ -13,6 +14,7 @@ pub enum Command {
     Edit,
     Interactive,
     Order,
+    #[cfg(feature = "eventkit")]
     Remind,
 }
 
@@ -23,6 +25,7 @@ impl Command {
             Edit => edit::execute(opt),
             Interactive => interactive::execute(opt),
             Order => order::execute(opt),
+            #[cfg(feature = "eventkit")]
             Remind => remind::execute(opt),
         }
     }
@@ -37,7 +40,8 @@ impl FromStr for Command {
             "edit" => Ok(Edit),
             "interactive" => Ok(Interactive),
             "order" => Ok(Order),
-            "remind" => Ok(Remind),
+        #[cfg(feature = "eventkit")]
+        "remind" => Ok(Remind),
             _ => Err(format!("failed to parse Command from '{}'", s)),
         }
     }

--- a/src/taskwarrior.rs
+++ b/src/taskwarrior.rs
@@ -1,6 +1,10 @@
 use std::fmt;
-use std::fs::{File, OpenOptions};
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::fs::File;
+#[cfg(feature = "eventkit")]
+use std::fs::OpenOptions;
+use std::io::{self, Read};
+#[cfg(feature = "eventkit")]
+use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::process::Command;
 use std::str;
@@ -9,6 +13,8 @@ use chrono::offset::Local;
 use chrono::{DateTime, NaiveDateTime, TimeZone};
 use serde::de;
 use serde::Deserialize;
+
+#[cfg(feature = "eventkit")]
 use shellexpand::tilde;
 
 use crate::opt::Opt;
@@ -124,6 +130,7 @@ impl Task {
         Ok(())
     }
 
+    #[cfg(feature = "eventkit")]
     /// Defines a user defined attribute (UDA) that stores the UUID of an operating system reminder
     /// onto the taskwarrior task.
     pub fn define_reminder_uda() -> io::Result<()> {
@@ -166,6 +173,7 @@ impl Task {
         }
     }
 
+    #[cfg(feature = "eventkit")]
     pub fn set_reminder_uuid(&mut self, uuid: String) -> io::Result<()> {
         Command::new("task")
             .arg(&self.uuid)


### PR DESCRIPTION
This PR adds an `eventkit` feature flag, which hides away all the eventkit related code (including everything to do with reminders), in order to allow the tool to be built on non-macos machines.